### PR TITLE
consumer_stats.py add main function

### DIFF
--- a/python_scripts/consumer_stats.py
+++ b/python_scripts/consumer_stats.py
@@ -225,8 +225,7 @@ def process_aggregate_trace(file):
 	#print stats
 	return stats
 
-#main
-
-#SIMULATION_DIR=os.getcwd()
-#SIMULATION_OUTPUT = SIMULATION_DIR + "/output/"
-#generateStatsPerSimulation(SIMULATION_OUTPUT)
+if __name__ == "__main__":
+	SIMULATION_DIR=os.getcwd()
+	SIMULATION_OUTPUT = SIMULATION_DIR + "/output/"
+	generateStatsPerSimulation(SIMULATION_OUTPUT)


### PR DESCRIPTION
Hello Daniel,
could we add this main function?
This would allows us to run the stats generator directly on an output folder and using it as imported library at the same time.
